### PR TITLE
Add all key types to initrd, not only ed25519

### DIFF
--- a/46sshd/sshd_config
+++ b/46sshd/sshd_config
@@ -1,4 +1,3 @@
-HostKey /etc/ssh/ssh_host_ed25519_key
 SyslogFacility AUTHPRIV
 PermitRootLogin yes
 AuthorizedKeysFile	.ssh/authorized_keys

--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ in comparison with a system whose root filesystem is unencrypted:
   by booting the machine from a Live stick) then she is also able
   to access all host keys on a unencrypted root filesystem
 
-That said, if the `/etc/ssh/dracut_ssh_host_ed25519_key{,.pub}`
-files are present then those are included, instead.
+That said, if `/etc/ssh/dracut_*key{,.pub}` files are present
+then those are included as host keys.
 
 As always, it depends on your threat model, whether it makes
 sense to use an extra host key for the initramfs or not. Using an


### PR DESCRIPTION
This includes all key types from either /etc/ssh/dracut_*key or
/etc/ssh/ssh_host_*key into initramfs.